### PR TITLE
backend: go module setup & simple api server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # General Rules
 **/.DS_Store
+*.swp
+*.swo
 
 # https://raw.githubusercontent.com/github/gitignore/master/Go.gitignore
 #

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,18 @@
+# OwlPlace Backend
+
+Documentation for the go service which handles OwlPlace API requests and
+maintains consensus with other replicas.
+
+## Structure
+
+### API Server: [`github.com/rgreen312/owlplace/backend/apiserver`]()
+
+Our API server supports the following requests:
+TODO
+
+### Consensus Module: [`github.com/rgreen312/owlplace/backend/consensus`]()
+
+The 
+
+
+## [GoDoc]()

--- a/server/apiserver/apiserver.go
+++ b/server/apiserver/apiserver.go
@@ -1,0 +1,20 @@
+package apiserver
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func Hello(w http.ResponseWriter, req *http.Request) {
+
+	fmt.Fprintf(w, "hello\n")
+}
+
+func Headers(w http.ResponseWriter, req *http.Request) {
+
+	for name, headers := range req.Header {
+		for _, h := range headers {
+			fmt.Fprintf(w, "%v: %v\n", name, h)
+		}
+	}
+}

--- a/server/apiserver/apiserver_test.go
+++ b/server/apiserver/apiserver_test.go
@@ -1,14 +1,49 @@
 package apiserver_test
 
 import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/rgreen312/owlplace/server/apiserver"
 )
 
-func TestHello(t *testing.T) {
-	want := "Hello, world."
-	if got := apiserver.Hello(); got != want {
-		t.Errorf("Hello() = %q, want %q", got, want)
+type handlerTest struct {
+	name          string
+	handler       func(http.ResponseWriter, *http.Request)
+	req           *http.Request
+	recorder      *httptest.ResponseRecorder
+	expectWritten []byte
+}
+
+func (h *handlerTest) Verify(t *testing.T) {
+	apiserver.Hello(h.recorder, h.req)
+	recordedBytes := h.recorder.Body.Bytes()
+	if bytes.Compare(recordedBytes, h.expectWritten) != 0 {
+		t.Errorf("Expected: %s, Got: %s", h.expectWritten, recordedBytes)
 	}
 }
+
+func TestHello(t *testing.T) {
+	tests := []*handlerTest{
+		&handlerTest{
+			name:          "hello_test",
+			handler:       apiserver.Hello,
+			req:           &http.Request{},
+			recorder:      httptest.NewRecorder(),
+			expectWritten: []byte("hello\n"),
+		},
+	}
+
+	for _, test := range tests {
+		test.Verify(t)
+	}
+}
+
+//func TestHeaders(t *testing.T) {
+//want := "Hello, world."
+//if got := apiserver.Hello(); got != want {
+//t.Errorf("Hello() = %q, want %q", got, want)
+//}
+//}

--- a/server/apiserver/apiserver_test.go
+++ b/server/apiserver/apiserver_test.go
@@ -1,14 +1,14 @@
-package server_test
+package apiserver_test
 
 import (
 	"testing"
 
-	"github.com/rgreen312/owlplace/server"
+	"github.com/rgreen312/owlplace/server/apiserver"
 )
 
 func TestHello(t *testing.T) {
 	want := "Hello, world."
-	if got := server.Hello(); got != want {
+	if got := apiserver.Hello(); got != want {
 		t.Errorf("Hello() = %q, want %q", got, want)
 	}
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,0 +1,3 @@
+module github.com/rgreen312/owlplace/server
+
+go 1.12

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,1 +1,2 @@
 github.com/rgreen312/owlplace v0.0.0-20190923194021-b586deed4655 h1:aR4BOStz/erio42Y1Ac0FJstagA6Nkk7DF9iR+6lHHg=
+github.com/rgreen312/owlplace v0.0.0-20190923203400-fede005253a4 h1:AVbah+qTtEg7/zVzjCXyGSUWluljqqJ0SQPUZcKIoho=

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,0 +1,1 @@
+github.com/rgreen312/owlplace v0.0.0-20190923194021-b586deed4655 h1:aR4BOStz/erio42Y1Ac0FJstagA6Nkk7DF9iR+6lHHg=

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,5 @@
+package server
+
+func Hello() string {
+	return "Hello, world."
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,5 +1,14 @@
-package server
+package main
 
-func Hello() string {
-	return "Hello, world."
+import (
+	"net/http"
+
+	"github.com/rgreen312/owlplace/server/apiserver"
+)
+
+func main() {
+	http.HandleFunc("/hello", apiserver.Hello)
+	http.HandleFunc("/headers", apiserver.Headers)
+
+	http.ListenAndServe(":3000", nil)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,14 @@
+package server_test
+
+import (
+	"testing"
+
+	"github.com/rgreen312/owlplace/server"
+)
+
+func TestHello(t *testing.T) {
+	want := "Hello, world."
+	if got := server.Hello(); got != want {
+		t.Errorf("Hello() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
This patch adds the structure for a simple go project as well as a very simple HTTP server.

### build

(from the 'server' directory)

```
go build
```

### run the server!

```
go run server.go
```

or 

```
./server
```

### make an api request

```shell
$ curl localhost:3000/hello
hello
```
