### PR TITLE
Bidirectional communication and in-memory image edits

### DIFF
--- a/server/apiserver/apiserver.go
+++ b/server/apiserver/apiserver.go
@@ -54,9 +54,12 @@ func (api *ApiServer) GetImage(w http.ResponseWriter, req *http.Request) {
 }
 
 func (api *ApiServer) UpdatePixel(w http.ResponseWriter, req *http.Request) {
-	fmt.Fprintf(os.Stdout, "Not Implemented.\n")
+	// Testing with some dummy data
+	m := consensus.BackendMessage{ Type: consensus.UPDATE_PIXEL, Data: "put pixel(10,10) (255,0,0,255)" }
+	api.sendc <- m
+	image_msg := <- api.recvc
+	fmt.Fprintf(os.Stdout, image_msg.Data)
 }
-
 
 func (api *ApiServer) Headers(w http.ResponseWriter, req *http.Request) {
 

--- a/server/apiserver/apiserver.go
+++ b/server/apiserver/apiserver.go
@@ -5,32 +5,58 @@ import (
 	"fmt"
 	"net/http"
 	"github.com/rgreen312/owlplace/server/consensus"
+	"html/template"
+
 )
 
+
 type ApiServer struct {
-	c chan consensus.BackendMessage
+	sendc chan consensus.BackendMessage
+	recvc chan consensus.ConsensusMessage
 }
 
-func NewApiServer(channel chan consensus.BackendMessage) *ApiServer {
+func NewApiServer(send_channel chan consensus.BackendMessage, recv_channel chan consensus.ConsensusMessage) *ApiServer {
 	return &ApiServer{
-		c: channel,
+		sendc: send_channel,
+		recvc: recv_channel,
 	}
 }
 
 func (api *ApiServer) ListenAndServe(){
-	http.HandleFunc("/hello", api.PutHello)
 	http.HandleFunc("/headers", api.Headers)
+	http.HandleFunc("/get_image", api.GetImage)
+	http.HandleFunc("/update_pixel", api.UpdatePixel)
 	http.ListenAndServe(":3000", nil)
 }
 
-func (api *ApiServer) PutHello(w http.ResponseWriter, req *http.Request) {
+
+func (api *ApiServer) GetImage(w http.ResponseWriter, req *http.Request) {
 	// Debug message
-	fmt.Fprintf(os.Stdout, "Sending Hello Message\n")
+	fmt.Fprintf(os.Stdout, "Getting Image From Raft\n")
 	// Construct the message
-	m := consensus.BackendMessage{ Dummy: "put server hello2!" }
+	m := consensus.BackendMessage{ Type: consensus.GET_IMAGE }
 	// Send a message through the channel
-	api.c <- m
+	api.sendc <- m
+	var ImageTemplate string = `<!DOCTYPE html>
+								<html lang="en"><head></head>
+								<body><img src="data:image/jpg;base64,{{.Image}}"></body>`
+	image_msg := <- api.recvc
+
+	if tmpl, err := template.New("image").Parse(ImageTemplate); err != nil {
+		fmt.Fprintf(os.Stdout, "Unable to parse image template.\n")
+	} else {
+		data := map[string]interface{}{"Image": image_msg.Data}
+		if err = tmpl.Execute(w, data); err != nil {
+			fmt.Fprintf(os.Stdout, "Unable to execute template.\n")
+		}
+	}
+
 }
+
+func (api *ApiServer) UpdatePixel(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(os.Stdout, "Not Implemented.\n")
+}
+
 
 func (api *ApiServer) Headers(w http.ResponseWriter, req *http.Request) {
 

--- a/server/apiserver/apiserver.go
+++ b/server/apiserver/apiserver.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"github.com/rgreen312/owlplace/server/consensus"
 	"html/template"
-
 )
 
 
@@ -54,11 +53,17 @@ func (api *ApiServer) GetImage(w http.ResponseWriter, req *http.Request) {
 }
 
 func (api *ApiServer) UpdatePixel(w http.ResponseWriter, req *http.Request) {
-	// Testing with some dummy data
-	m := consensus.BackendMessage{ Type: consensus.UPDATE_PIXEL, Data: "put pixel(10,10) (255,0,0,255)" }
-	api.sendc <- m
-	image_msg := <- api.recvc
-	fmt.Fprintf(os.Stdout, image_msg.Data)
+
+	// Decode the request
+	update := req.URL.Query().Get("update")
+	if(update != ""){
+		fmt.Fprintf(os.Stdout, update)
+		// Testing with some dummy data
+		m := consensus.BackendMessage{ Type: consensus.UPDATE_PIXEL, Data: update }
+		api.sendc <- m
+		image_msg := <- api.recvc
+		fmt.Fprintf(os.Stdout, image_msg.Data)
+	}
 }
 
 func (api *ApiServer) Headers(w http.ResponseWriter, req *http.Request) {

--- a/server/consensus/consensus.go
+++ b/server/consensus/consensus.go
@@ -1,23 +1,21 @@
 package consensus
 
 import (
-	"bufio"
-	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"syscall"
-	"time"
+	// "context"
+	// "time"
 
 	"github.com/lni/dragonboat/v3"
 	"github.com/lni/dragonboat/v3/config"
 	"github.com/lni/dragonboat/v3/logger"
 	"github.com/lni/goutils/syncutil"
+
 )
 
 
@@ -33,8 +31,21 @@ const (
 	GET
 )
 
+const (
+	GET_IMAGE int = 0
+	UPDATE_PIXEL int = 1
+	ADD_USER int = 2
+	GET_LAST_USER_UPDATE int = 3
+)
+
+type ConsensusMessage struct {
+	Type int
+	Data string
+}
+
 type BackendMessage struct {
-	Dummy string
+	Type int
+	Data string
 }
 
 
@@ -47,30 +58,13 @@ var (
 	}
 )
 
-func parseCommand(msg string) (RequestType, string, string, bool) {
-	parts := strings.Split(strings.TrimSpace(msg), " ")
-	if len(parts) == 0 || (parts[0] != "put" && parts[0] != "get") {
-		return PUT, "", "", false
-	}
-	if parts[0] == "put" {
-		if len(parts) != 3 {
-			return PUT, "", "", false
-		}
-		return PUT, parts[1], parts[2], true
-	}
-	if len(parts) != 2 {
-		return GET, "", "", false
-	}
-	return GET, parts[1], "", true
-}
-
 func printUsage() {
 	fmt.Fprintf(os.Stdout, "Usage - \n")
 	fmt.Fprintf(os.Stdout, "put key value\n")
 	fmt.Fprintf(os.Stdout, "get key\n")
 }
 
-func MainConsensus(c chan BackendMessage){
+func MainConsensus(recvc chan BackendMessage, sendc chan ConsensusMessage){
 
 	nodeID := flag.Int("nodeid", 1, "NodeID to use")
 	addr := flag.String("addr", "", "Nodehost address")
@@ -129,117 +123,53 @@ func MainConsensus(c chan BackendMessage){
 		os.Exit(1)
 	}
 	raftStopper := syncutil.NewStopper()
-	consoleStopper := syncutil.NewStopper()
-	ch := make(chan string, 16)
-	consoleStopper.RunWorker(func() {
-		reader := bufio.NewReader(os.Stdin)
-		for {
-			s, err := reader.ReadString('\n')
-			if err != nil {
-				close(ch)
-				return
-			}
-			if s == "exit\n" {
-				raftStopper.Stop()
-				nh.Stop()
-				return
-			}
-			ch <- s
-		}
-	})
-
-
-	printUsage()
 	raftStopper.RunWorker(func() {
-		cs := nh.GetNoOPSession(exampleClusterID)
+		// cs := nh.GetNoOPSession(exampleClusterID)
 		for {
 			select {
-			case v, ok := <-ch:
+			case backend_msg, ok := <-recvc:
 				if !ok {
 					return
 				}
-				msg := strings.Replace(v, "\n", "", 1)
-				// input message must be in the following formats -
-				// put key value
-				// get key
-				rt, key, val, ok := parseCommand(msg)
-				if !ok {
-					fmt.Fprintf(os.Stderr, "invalid input\n")
-					printUsage()
-					continue
-				}
-				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-				if rt == PUT {
-					kv := &KVData{
-						Key: key,
-						Val: val,
-					}
-					data, err := json.Marshal(kv)
-					if err != nil {
-						panic(err)
-					}
-					_, err = nh.SyncPropose(ctx, cs, data)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "SyncPropose returned error %v\n", err)
-					}
-				} else {
-					result, err := nh.SyncRead(ctx, exampleClusterID, []byte(key))
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "SyncRead returned error %v\n", err)
-					} else {
-						fmt.Fprintf(os.Stdout, "query key: %s, result: %s\n", key, result)
-					}
-				}
-				cancel()
-			case <-raftStopper.ShouldStop():
-				return
-			}
-		}
-	})
 
+				// ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 
-	raftStopper.RunWorker(func() {
-		cs := nh.GetNoOPSession(exampleClusterID)
-		for {
-			select {
-			case backend_msg, ok := <-c:
-				if !ok {
-					return
+				switch backend_msg.Type {
+				case GET_IMAGE:
+					fmt.Fprintf(os.Stderr, "GET_IMAGE Not Implemented\n", err)
+				case UPDATE_PIXEL:
+					fmt.Fprintf(os.Stderr, "UPDATE_PIXEL Not Implemented\n", err)
+				case ADD_USER:
+					fmt.Fprintf(os.Stderr, "ADD_USER Not Implemented\n", err)
+				case GET_LAST_USER_UPDATE:
+					fmt.Fprintf(os.Stderr, "GET_LAST_USER_UPDATE Not Implemented\n", err)
 				}
-				v := backend_msg.Dummy
-				msg := strings.Replace(v, "\n", "", 1)
-				// input message must be in the following formats -
-				// put key value
-				// get key
-				rt, key, val, ok := parseCommand(msg)
-				if !ok {
-					fmt.Fprintf(os.Stderr, "invalid input\n")
-					printUsage()
-					continue
-				}
-				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-				if rt == PUT {
-					kv := &KVData{
-						Key: key,
-						Val: val,
-					}
-					data, err := json.Marshal(kv)
-					if err != nil {
-						panic(err)
-					}
-					_, err = nh.SyncPropose(ctx, cs, data)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "SyncPropose returned error %v\n", err)
-					}
-				} else {
-					result, err := nh.SyncRead(ctx, exampleClusterID, []byte(key))
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "SyncRead returned error %v\n", err)
-					} else {
-						fmt.Fprintf(os.Stdout, "query key: %s, result: %s\n", key, result)
-					}
-				}
-				cancel()
+				
+				// rt, key, val, ok := parseCommand(msg)
+				
+
+				// if rt == PUT {
+				// 	kv := &KVData{
+				// 		Key: key,
+				// 		Val: val,
+				// 	}
+				// 	data, err := json.Marshal(kv)
+				// 	if err != nil {
+				// 		panic(err)
+				// 	}
+				// 	_, err = nh.SyncPropose(ctx, cs, data)
+				// 	if err != nil {
+				// 		fmt.Fprintf(os.Stderr, "SyncPropose returned error %v\n", err)
+				// 	}
+				// } else {
+				// 	result, err := nh.SyncRead(ctx, exampleClusterID, []byte(key))
+				// 	if err != nil {
+				// 		fmt.Fprintf(os.Stderr, "SyncRead returned error %v\n", err)
+				// 	} else {
+				// 		fmt.Fprintf(os.Stdout, "query key: %s, result: %s\n", key, result)
+				// 	}
+				// }
+				// cancel()
 			case <-raftStopper.ShouldStop():
 				return
 			}

--- a/server/consensus/consensus.go
+++ b/server/consensus/consensus.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
+	"encoding/json"
 	"image"
 	"image/png"
 	"os"
@@ -12,6 +13,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"syscall"
+	"time"
+	"context"
+	"strings"
 
 	// "context"
 	// "time"
@@ -39,6 +43,8 @@ const (
 	UPDATE_PIXEL         int = 1
 	ADD_USER             int = 2
 	GET_LAST_USER_UPDATE int = 3
+	SUCCESS              int = 4
+	FAILURE              int = 5
 )
 
 type ConsensusMessage struct {
@@ -53,7 +59,7 @@ func NewImageMessage(img image.RGBA) ConsensusMessage {
 
 	// The Buffer satisfies the Writer interface so we can use it with Encode
 	// In previous example we encoded to a file, this time to a temp buffer
-	png.Encode(&buff, img)
+	png.Encode(&buff, &img)
 
 	// Encode the bytes in the buffer to a base64 string
 	encodedString := base64.StdEncoding.EncodeToString(buff.Bytes())
@@ -63,6 +69,21 @@ func NewImageMessage(img image.RGBA) ConsensusMessage {
 		Data: encodedString,
 	}
 }
+
+func SuccessMessage() ConsensusMessage {
+	return ConsensusMessage{
+		Type: SUCCESS,
+		Data: "Success\n",
+	}
+}
+
+func FailureMessage() ConsensusMessage {
+	return ConsensusMessage{
+		Type: FAILURE,
+		Data: "Failure\n",
+	}
+}
+
 
 type BackendMessage struct {
 	Type int
@@ -83,6 +104,24 @@ func printUsage() {
 	fmt.Fprintf(os.Stdout, "put key value\n")
 	fmt.Fprintf(os.Stdout, "get key\n")
 }
+
+func parseCommand(msg string) (RequestType, string, string, bool) {
+	parts := strings.Split(strings.TrimSpace(msg), " ")
+	if len(parts) == 0 || (parts[0] != "put" && parts[0] != "get") {
+		return PUT, "", "", false
+	}
+	if parts[0] == "put" {
+		if len(parts) != 3 {
+			return PUT, "", "", false
+		}
+		return PUT, parts[1], parts[2], true
+	}
+	if len(parts) != 2 {
+		return GET, "", "", false
+	}
+	return GET, parts[1], "", true
+}
+
 
 func MainConsensus(recvc chan BackendMessage, sendc chan ConsensusMessage) {
 
@@ -140,61 +179,57 @@ func MainConsensus(recvc chan BackendMessage, sendc chan ConsensusMessage) {
 	}
 	var imgGetter func() image.RGBA
 	stateMachineProvider := func(clusterID uint64, nodeID uint64) sm.IOnDiskStateMachine {
-		dkv := NewDiskKV(clusterID, nodeID)
-		imgGetter = dkv.GetInMemoryImage
+		dkv := NewDiskKV(clusterID, nodeID).(*DiskKV)
+		imgGetter =  dkv.GetInMemoryImage
 		return dkv
 	}
-	if err := nh.StartOnDiskCluster(peers, *join, NewDiskKV, rc); err != nil {
+	if err := nh.StartOnDiskCluster(peers, *join, stateMachineProvider, rc); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to add cluster, %v\n", err)
 		os.Exit(1)
 	}
 	raftStopper := syncutil.NewStopper()
 	raftStopper.RunWorker(func() {
-		// cs := nh.GetNoOPSession(exampleClusterID)
+		cs := nh.GetNoOPSession(exampleClusterID)
 		for {
 			select {
 			case backend_msg, ok := <-recvc:
 				if !ok {
 					return
 				}
-
-				// ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-
 				switch backend_msg.Type {
 				case GET_IMAGE:
-					recv_channel <- NewImageMessage(imgGetter())
+					sendc <- NewImageMessage(imgGetter())
 				case UPDATE_PIXEL:
-					fmt.Fprintf(os.Stderr, "UPDATE_PIXEL Not Implemented\n", err)
+					ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+					_, key, val, ok := parseCommand(backend_msg.Data)
+					if(!ok){
+						sendc <- FailureMessage()
+					} else {
+						kv := &KVData{
+							Key: key,
+							Val: val,
+						}
+						data, err := json.Marshal(kv)
+						if err != nil {
+							panic(err)
+						}
+						_, err = nh.SyncPropose(ctx, cs, data)
+						if err != nil {
+							fmt.Fprintf(os.Stderr, "SyncPropose returned error %v\n", err)
+						}
+						sendc <- SuccessMessage()
+					}
+					cancel()
+
 				case ADD_USER:
 					fmt.Fprintf(os.Stderr, "ADD_USER Not Implemented\n", err)
 				case GET_LAST_USER_UPDATE:
 					fmt.Fprintf(os.Stderr, "GET_LAST_USER_UPDATE Not Implemented\n", err)
 				}
 
-				// rt, key, val, ok := parseCommand(msg)
 
-				// if rt == PUT {
-				// 	kv := &KVData{
-				// 		Key: key,
-				// 		Val: val,
-				// 	}
-				// 	data, err := json.Marshal(kv)
-				// 	if err != nil {
-				// 		panic(err)
-				// 	}
-				// 	_, err = nh.SyncPropose(ctx, cs, data)
-				// 	if err != nil {
-				// 		fmt.Fprintf(os.Stderr, "SyncPropose returned error %v\n", err)
-				// 	}
-				// } else {
-				// 	result, err := nh.SyncRead(ctx, exampleClusterID, []byte(key))
-				// 	if err != nil {
-				// 		fmt.Fprintf(os.Stderr, "SyncRead returned error %v\n", err)
-				// 	} else {
-				// 		fmt.Fprintf(os.Stdout, "query key: %s, result: %s\n", key, result)
-				// 	}
-				// }
-				// cancel()
+				
+
 			case <-raftStopper.ShouldStop():
 				return
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-
 	"github.com/rgreen312/owlplace/server/apiserver"
 	"github.com/rgreen312/owlplace/server/consensus"
 )
@@ -9,12 +8,13 @@ import (
 
 func main() {
 	// Make the backend channel that the api server and consensus module communicate with
-	backend_channel := make(chan consensus.BackendMessage)
+	api_to_backend_channel := make(chan consensus.BackendMessage)
+	backend_to_api_channel := make(chan consensus.ConsensusMessage)
 	// Start API listening asynchronously (TODO: pass in channel)
-	server := apiserver.NewApiServer(backend_channel)
+	server := apiserver.NewApiServer(api_to_backend_channel, backend_to_api_channel)
 	go server.ListenAndServe()
 
 	// Start consensus service
-	consensus.MainConsensus(backend_channel)
+	consensus.MainConsensus(api_to_backend_channel, backend_to_api_channel)
 
 }


### PR DESCRIPTION
Modifies the image in memory as key-value update requests are sent to the server
The format of the request from consensus to kv update is as follows.

`pixel(x,y) (r,g,b,a)`

Note: I don't know how to access the key-value store properties from the consensus package.

I also set up message types for sending and receiving between the API and the consensus module 

This PR closes #15 and #14  