### PR TITLE
done with user data stuff

### DIFF
--- a/server/apiserver/apiserver.go
+++ b/server/apiserver/apiserver.go
@@ -66,6 +66,24 @@ func (api *ApiServer) UpdatePixel(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func (api *ApiServer) GetLastUserModification(user_id string) string{
+
+	// Testing with some dummy data
+	m := consensus.BackendMessage{ Type: consensus.GET_LAST_USER_UPDATE, Data: fmt.Sprintf("get %s", user_id)}
+	api.sendc <- m
+	image_msg := <- api.recvc
+	return image_msg.Data
+}
+
+func (api *ApiServer) SetLastUserModification(user_id string, last_modification string) bool{
+
+	// Testing with some dummy data
+	m := consensus.BackendMessage{ Type: consensus.SET_LAST_USER_UPDATE, Data: fmt.Sprintf("put %s %s", user_id, last_modification)}
+	api.sendc <- m
+	image_msg := <- api.recvc
+	return image_msg.Type == consensus.SUCCESS
+}
+
 func (api *ApiServer) Headers(w http.ResponseWriter, req *http.Request) {
 
 	for name, headers := range req.Header {


### PR DESCRIPTION
This pull request equips the backend API with two additional functions for storing and modifying user data. Communication with the consensus module is mediated using two channels

- ApiServer.sendc: A channel for sending `consensus.BackendMessage` structs to the consensus module 
- ApiServer.recv: A channel for receiving `consensus.ConsensusMessage` structs from the consensus module

Both of these structs contain two properties:
1. Type: An integer representing the type of the message (types described in server/consensus/consensus.go)
2. Data: A string representing the data that accompanies that type

The two types that are relevant for user data modification are the following
1. `consensus.GET_LAST_USER_UPDATE`: Data is "get %s" where %s corresponds to the user id. The consensus module will return an error if no user is found with that id or a string timestamp for the last user modification.
2. `consensus.SET_LAST_USER_UPDATE`: Data is "put %s %s" where the first string is the user id and the second string is the timestamp. The consensus module will return a success message if the store was successful or a failure message if there was an error in processing the message. 


Examples for how to use the channels and the data structs can be found in the `GetLastUserModification` and `SetLastUserModification` of the server/apiserver/apiserver.go file.



