### PR TITLE
First commit for discovery server

### DIFF
--- a/discovery_server/.gitignore
+++ b/discovery_server/.gitignore
@@ -1,0 +1,1 @@
+discovery_server

--- a/discovery_server/go.mod
+++ b/discovery_server/go.mod
@@ -1,0 +1,5 @@
+module github.com/rgreen312/owlplace/discovery_server
+
+go 1.12
+
+require github.com/lni/goutils v1.0.2

--- a/discovery_server/go.sum
+++ b/discovery_server/go.sum
@@ -1,0 +1,3 @@
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/lni/goutils v1.0.2/go.mod h1:f2YgTtVeGFUdJrZJmtf0S05qYvSZXdmBxa5Z8nhBU/Q=

--- a/discovery_server/server.go
+++ b/discovery_server/server.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"fmt"
+)
+
+type HostList struct {
+	hosts []string
+}
+
+// Server list constructor
+func NewHostList() *HostList{
+	// Construct with empty list
+	return &HostList{
+		hosts: []string{},
+	}
+}
+
+// Server list register host method
+func (hostList *HostList) registerHost(w http.ResponseWriter, req *http.Request){
+	host := req.URL.Query().Get("host")
+	hostList.hosts = append(hostList.hosts, host)
+}
+
+// Server list get hosts method
+func (hostList *HostList) getHosts(w http.ResponseWriter, req *http.Request){
+	fmt.Fprintf(w, "%s", strings.Join(hostList.hosts[:], "\n"))
+}
+
+func main() {
+	hostList := NewHostList()
+	http.HandleFunc("/register_host", hostList.registerHost)
+	http.HandleFunc("/get_hosts", hostList.getHosts)
+
+	// TODO: Need to set up a method to continually ping all of the hosts in the hostlist to see if they are still active
+	http.ListenAndServe(fmt.Sprintf(":%d", 3020), nil)
+}


### PR DESCRIPTION
This is the discovery server that will be used for each node running the consensus algorithm to know the IP addresses of the other consensus nodes in order to communicate with them.

This code is simply two HTTP functions
register_host - add a host to the active host list
get_hosts - get all of the hosts that are currently on the host list

To test it out, run `go build` inside of the discovery server directory and then enter the following URLs in your browser

```
http://localhost:3020/register_host?host=10.0.0.1
http://localhost:3020/register_host?host=10.0.0.2
http://localhost:3020/register_host?host=10.0.0.3
http://localhost:3020/get_hosts
```

You should see a list of the registered hosts.