### PR TITLE
[Front end]: Display canvas on GitHub Pages site

### DIFF
--- a/client/src/RoutingContainer.tsx
+++ b/client/src/RoutingContainer.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { HashRouter as Router, Route } from 'react-router-dom';
 import ScrollToTop from './components/ScrollToTop';
 import CanvasPageContainer from './canvas/containers/CanvasPageContainer';
 import AboutPage from './about/containers/AboutContainer';
@@ -8,7 +8,7 @@ import Footer from './footer/components/Footer';
 import ErrorPage from './error/components/Error';
 
 const RoutingContainer: FC = () => (
-  <Router>
+  <Router basename='/OwlPlace'>
     <ScrollToTop>
       <Header />
       <Route exact path='/' component={CanvasPageContainer} />


### PR DESCRIPTION
Previously the canvas was not showing up on the GitHub site. This fixes that by switching to the HashRouter and adding a base name.
<img width="1039" alt="Screen Shot 2019-10-31 at 4 12 51 PM" src="https://user-images.githubusercontent.com/10169700/67986555-4dab2100-fbf9-11e9-883b-c1fe9af9f221.png">
