### PR TITLE
docker: improve build time + process

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM golang:1.13.1-alpine3.10 AS rocksbuilder
+FROM golang:1.13.1-alpine3.10 AS builder
 
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories
 RUN apk add --update --no-cache build-base linux-headers git cmake bash #wget mercurial g++ autoconf libgflags-dev cmake  bash jemalloc
@@ -37,11 +37,12 @@ RUN cd /tmp && \
     cp -r include/* /usr/include/ && \
     rm -R /tmp/rocksdb/
 
+FROM builder AS compile-image
+
 COPY server /app
+RUN cd /app && go build
 
-RUN cd /app && go build 
-
-FROM alpine:3.10 AS server
+FROM alpine:3.10 AS runtime-image
 
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories
 RUN apk add --update --no-cache \
@@ -60,13 +61,13 @@ RUN apk add --update --no-cache \
         libtbb-dev@testing \
         libtbb@testing
 
-COPY --from=rocksbuilder /usr/lib/libgflags* /usr/lib/
-COPY --from=rocksbuilder /usr/include/gflags /usr/include/gflags
-COPY --from=rocksbuilder /usr/include/google /usr/include/google
-COPY --from=rocksbuilder /usr/local/rocksdb /usr/local/rocksdb
-COPY --from=rocksbuilder /usr/lib/librocksdb.so* /usr/lib/
-COPY --from=rocksbuilder /usr/local/rocksdb/include/rocksdb /usr/include/rocksdb
-COPY --from=rocksbuilder /app/server /bin/server
+COPY --from=builder /usr/lib/libgflags* /usr/lib/
+COPY --from=builder /usr/include/gflags /usr/include/gflags
+COPY --from=builder /usr/include/google /usr/include/google
+COPY --from=builder /usr/local/rocksdb /usr/local/rocksdb
+COPY --from=builder /usr/lib/librocksdb.so* /usr/lib/
+COPY --from=builder /usr/local/rocksdb/include/rocksdb /usr/include/rocksdb
+COPY --from=compile-image /app/server /bin/server
 
 ENV NODEID 0
 ENV CONFIG /usr/share/owlplace.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+DOCKERFILE = $(PWD)/Dockerfile.server
+OWLPLACE_CACHE = $(PWD)/.go-cache
+BUILD_IMAGE = owlplace-builder
+COMPILE_IMAGE = owlplace-fat
+RUNTIME_IMAGE = owlplace
+PROJECT_DIR = $(PWD)/server
+
+all: image
+
+builder: $(DOCKERFILE)
+	docker build . -f $(DOCKERFILE) --target builder -t $(BUILD_IMAGE)
+
+build:
+	docker run --rm -it -v $(PROJECT_DIR):/app -v $(OWLPLACE_CACHE):/go/pkg/mod --workdir /app $(BUILD_IMAGE) go build
+
+docker-build:
+	docker build . -f $(DOCKERFILE) --target compile-image -t $(COMPILE_IMAGE)
+
+image: $(DOCKERFILE)
+	docker build . -f $(DOCKERFILE) --target runtime-image -t $(RUNTIME_IMAGE)
+
+.PHONY: builder image build docker-build

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Distributed Program Construction during the Fall of 2019.
 
 ### [Frontend](./client)
 
-### [Backend](./backend)
+### [Backend](./server)

--- a/server/README.md
+++ b/server/README.md
@@ -3,28 +3,38 @@
 Documentation for the go service which handles OwlPlace API requests and
 maintains consensus with other replicas.
 
-## API Server
+## Developing with Docker
 
-Go Package: [`github.com/rgreen312/owlplace/server/apiserver`](https://github.com/rgreen312/OwlPlace/tree/master/server/apiserver)
+Ensure you have a working version of Docker and GNU Make installed.  The
+Makefile provided stores some convenience directives for building and running
+our service.
 
-### Endpoints & Supported Requests
+**Note for Windows: If Docker doesn't work, try installing [VirtualBox
+5.2.6](https://download.virtualbox.org/virtualbox/5.2.6/), other versions
+may/may not work.**
 
-TODO
-
-## Consensus Module
-
-Go Package: [`github.com/rgreen312/owlplace/server/apiserver`](https://github.com/rgreen312/OwlPlace/tree/master/server/apiserver)
-
-## Development Setup
-
-1. Install Go: https://golang.org/doc/install#install
-1. Install RocksDB: https://github.com/facebook/rocksdb/blob/master/INSTALL.md
-1. Clone this repo **outside** of `$GOPATH`
-1. Building: navigate to this folder and run `go build`!
-1. Testing: navigate to this golder and run `go test`!
+### building and packaging
 
 
-## Building with Docker
+#### building the dependency image
+
+```
+$ make builder
+```
+
+#### building the code
+
+```
+$ make build
+```
+
+#### building a runtime image
+
+```
+$ make image
+```
+
+### running a cluster
 
 To start a cluster member, first define a cluster configuration file:
 
@@ -41,19 +51,16 @@ To start a cluster member, first define a cluster configuration file:
 where the keys of the JSON object are the node IDs of the cluster members.
 This is the `docker-owlplace.json` file.
 
-## building
-
-The Dockerfile (`Dockerfile.server`) leverages a multi-stage builder pattern that builds our deps, our service, and then copies our final binaries into a runtime image.  To build (from the main folder), run:
-
-```shell
-docker build . -f Dockerfile.server -t owlplace
+To deploy 3 services as defined in `docker-compose.yml`, run:
+```
+$ docker-compose up
 ```
 
-For Windows: If Docker doesn't work, try installing [VirtualBox 5.2.6](https://download.virtualbox.org/virtualbox/5.2.6/), other versions may/may not work.
-
-## running
-
-At this point, we have an image that will run our service packaged with its dependencies.  To run several of them at one time, we'll use [docker compose](https://docs.docker.com/compose/) to define a few services.  See `docker-compose.yml` for an example, and run `docker-compose up` to start 3 services.
-
-If localhost:3001 doesn't work, try using the docker IP (docker-machine ip in terminal) insteadl of localhost, like \[docker IP\]:3001
-
+This should run 3 backend services that communicate together over their own
+docker network.  Note that in our two config files (`docker-compose.yml` and
+`docker-owlplace.json`) we set our API ports to `3000` and bind those container
+ports to host ports `3001`, `3002`, and `3003`.  So, you should be able to make
+API requests against our API at `localhost:3001`.  If you're using an older
+version of Windows, it's possible Docker failed to correctly map these ports,
+so you should replace `localhost` with your docker machine's IP address, which
+you can find using `docker-machine ip` in the Docker Quickstart Terminal.


### PR DESCRIPTION
This patch should speed up the builds a little bit, as well as make them
a bit easier to trigger.  After running `make builder` once, folks
should be able to run `make build` about as quickly as running `go
build` would take!