### PR TITLE
Image data messages/ client initial grid.

### DIFF
--- a/client/src/about/components/About.tsx
+++ b/client/src/about/components/About.tsx
@@ -15,7 +15,7 @@ const About: FC<Props> = ({ sendUpdateMessage, sendLoginMessage }) => (
     <h2>TESTING AREA</h2>
       <p>Click "Pixel 1" to send an update message to the server!
       </p>
-        <button onClick = {() => sendUpdateMessage("user1", 500, 500, 25, 125, 255)} id="p1"> Pixel 1 </button>
+        <button onClick = {() => sendUpdateMessage("user1", 500, 500, 0, 125, 255)} id="p1"> Pixel 1 </button>
         <button onClick = {() => sendLoginMessage("testemail@gmail.com")} id="login"> User Login </button>
     <h1>OwlPlace</h1>
 

--- a/client/src/about/components/About.tsx
+++ b/client/src/about/components/About.tsx
@@ -15,7 +15,7 @@ const About: FC<Props> = ({ sendUpdateMessage, sendLoginMessage }) => (
     <h2>TESTING AREA</h2>
       <p>Click "Pixel 1" to send an update message to the server!
       </p>
-        <button onClick = {() => sendUpdateMessage("user1", 10, 400, 255, 255, 255)} id="p1"> Pixel 1 </button>
+        <button onClick = {() => sendUpdateMessage("user1", 500, 500, 25, 125, 255)} id="p1"> Pixel 1 </button>
         <button onClick = {() => sendLoginMessage("testemail@gmail.com")} id="login"> User Login </button>
     <h1>OwlPlace</h1>
 

--- a/client/src/canvas/actions.ts
+++ b/client/src/canvas/actions.ts
@@ -7,12 +7,24 @@ import { getZoomFactor, getCanvasContext } from './selectors';
 const fetchImageDataStart = () => ({
   type: ActionTypes.FetchImageStart
 });
-
 export type FetchImageDataStart = ReturnType<typeof fetchImageDataStart>;
 
 export const fetchImageData = () => dispatch => {
   dispatch(fetchImageDataStart());
 };
+
+export const setImage = (image: string) => ({
+  type: ActionTypes.FetchImageSuccess,
+  payload: {
+    image
+  }
+});
+export type SetInitialImage = ReturnType<typeof setImage>;
+
+export const setInitialImage = (image: string) => dispatch => {
+  console.log('setting image in state');
+  dispatch(setImage(image));
+}
 
 const registerContext = (ctx: CanvasRenderingContext2D) => ({
   type: ActionTypes.RegisterContext,

--- a/client/src/canvas/components/Canvas.tsx
+++ b/client/src/canvas/components/Canvas.tsx
@@ -17,6 +17,7 @@ interface Props {
   onUpdatePixel: (newColor: Color, x: number, y: number) => void;
   zoomFactor: number;
   setZoomFactor: (newZoom: number) => void;
+  initialImage?: string;
 }
 
 interface State {
@@ -160,6 +161,21 @@ class Canvas extends Component<Props, State> {
         isDrag: false
       });
     });
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    console.log('component updated');
+    if (this.props.initialImage && this.props.initialImage !== prevProps.initialImage) {
+      console.log('image drawn');
+      const context = this.canvasRef.current!.getContext('2d');
+      if (context) {
+        const image = new Image();
+        image.onload = function() {
+          context.drawImage(image, 0, 0);
+        };
+        image.src = this.props.initialImage;
+      }
+    }
   }
 
   updateTranslate(ev: MouseEvent) {

--- a/client/src/canvas/containers/CanvasContainer.tsx
+++ b/client/src/canvas/containers/CanvasContainer.tsx
@@ -6,9 +6,9 @@ import {
   updateCursorPosition,
   clearCursorPosition,
   setZoomFactor,
-  updatePixel
+  updatePixel,
 } from '../actions';
-import { getZoomFactor, getCurrentPosition } from '../selectors';
+import { getZoomFactor, getCurrentPosition, getInitialImage } from '../selectors';
 import { Color } from '../types';
 
 interface DispatchProps {
@@ -24,6 +24,7 @@ interface StateProps {
   zoomFactor: number;
   position: { x: number; y: number } | undefined;
   isLoading: boolean;
+  initialImage?: string;
 }
 
 const mapDispatchToProps: DispatchProps = {
@@ -38,7 +39,8 @@ const mapStateToProps = (state): StateProps => ({
   receivedError: receivedError(state),
   zoomFactor: getZoomFactor(state),
   position: getCurrentPosition(state),
-  isLoading: getIsLoadingState(state)
+  isLoading: getIsLoadingState(state),
+  initialImage: getInitialImage(state),
 });
 
 export default connect(

--- a/client/src/canvas/reducers.ts
+++ b/client/src/canvas/reducers.ts
@@ -2,7 +2,7 @@ import { Color } from './types';
 import * as ActionTypes from './actionTypes';
 import { combineReducers } from 'redux';
 import { createReducer } from '../createReducer';
-import { RegisterContext, UpdatePosition, SetZoom } from './actions';
+import { RegisterContext, UpdatePosition, SetZoom, SetInitialImage } from './actions';
 import * as WebSocketActionTypes from '../websocket/actionTypes';
 import { DEFAULT_ZOOM } from './constants';
 
@@ -29,8 +29,15 @@ const zoomFactor = createReducer<State['zoomFactor']>(DEFAULT_ZOOM, {
   [ActionTypes.SetZoom]: (state, action: SetZoom) => action.payload.zoom
 });
 
+const initialImage = createReducer<State['initialImage']>(null, {
+  [ActionTypes.FetchImageError]: () => null,
+  [ActionTypes.FetchImageStart]: () => null,
+  [ActionTypes.FetchImageSuccess]: (state, action: SetInitialImage) => action.payload.image,
+})
+
 export default combineReducers({
   canvasContext,
   curPosition,
-  zoomFactor
+  zoomFactor,
+  initialImage
 });

--- a/client/src/canvas/selectors.ts
+++ b/client/src/canvas/selectors.ts
@@ -11,3 +11,6 @@ export const getCurrentPosition = (
   state.canvas.curPosition || undefined;
 
 export const getZoomFactor = (state: State): number => state.canvas.zoomFactor;
+
+export const getInitialImage = (state: State): string | undefined => 
+  state.canvas.initialImage || undefined;

--- a/client/src/message.ts
+++ b/client/src/message.ts
@@ -1,6 +1,24 @@
 export const ERROR = -1;
+export const OPEN = 0;
+export const DRAWPIXEL = 1;
+export const LOGINUSER = 2;
+export const UPDATEPIXEL = 3;
 export const IMAGE = 4;
 export const TESTING = 5;
+export const DRAWRESPONSE = 6;
+export const CLOSE = 9;
+
+/*
+    Error        MsgType = -1
+	Open         MsgType = 0
+	DrawPixel    MsgType = 1
+    LoginUser    MsgType = 2
+    UpdatePixel  MsgType = 3
+	Image        MsgType = 4
+	Testing      MsgType = 5
+	DrawResponse MsgType = 6
+    Close        MsgType = 9
+    */
 
 export interface Msg {
     type: number;

--- a/client/src/websocket/actions.ts
+++ b/client/src/websocket/actions.ts
@@ -122,6 +122,16 @@ export const sendUpdateMessage = (id, x, y, r, g, b) => (dispatch, getState) => 
   const socket = getWebSocket(getState());
   if (socket) {
     socket.send(makeUpdateMessage(id, x, y, r, g, b));
+
+    // The follwing should be REMOVED when testing is done/ you want to only do single pixels
+    let lower = 495;
+    let upper = 505;
+    for (let i = lower; i < upper; i++) {
+      for (let j = lower; j < upper; j++) {
+        console.log("sending..")
+        socket.send(makeUpdateMessage(id, i, j, r, g, b));
+      }
+    }
   }
 }
 

--- a/client/src/websocket/actions.ts
+++ b/client/src/websocket/actions.ts
@@ -1,7 +1,8 @@
 import { HOSTNAME } from '../constants';
 import * as ActionTypes from './actionTypes';
 import { getWebSocket } from './selectors';
-import { ERROR, IMAGE, Msg, ErrorMsg, ImageMsg, TESTING } from '../message';
+import { ERROR, IMAGE, Msg, ErrorMsg, ImageMsg, TESTING, DRAWRESPONSE } from '../message';
+import { setImage } from '../canvas/actions';
 
 const startConnect = () => ({
   type: ActionTypes.StartConnect
@@ -58,8 +59,6 @@ export const openWebSocket = () => dispatch => {
 
   socket.onmessage = event => {
     const { data } = event;
-    console.log("data is" + data);
-    console.log(typeof(data))
     let json = JSON.parse(data);
     switch (json.type) {
         case IMAGE: {
@@ -67,11 +66,19 @@ export const openWebSocket = () => dispatch => {
             let imageString = json.formatString
             console.log("Received an IMAGE message from the server!");
             console.log("Format string: " + imageString);
+            dispatch(setImage('data:image/png;base64,' + imageString));
             break;
         }
         case TESTING: {
           console.log("Received a TESTING message from the server!");
           console.log("Message: " + json.msg);
+          break;
+        }
+        case DRAWRESPONSE: {
+          let status = json.status
+          console.log("Received a DRAWRESPONSE message from the server!");
+          console.log("The status was " + status)
+          break;
         }
         default: {
             console.log("Received a message from the server of an unknown type, message: " + data);

--- a/server/apiserver/apiserver.go
+++ b/server/apiserver/apiserver.go
@@ -155,11 +155,11 @@ func (api *ApiServer) CallUpdatePixel(x int, y int, r int, g int, b int, userID 
 	// format message back to the client saying it's been updated or if it failed.
 	if consensus_response.Type == consensus.SUCCESS {
 		fmt.Fprintf(os.Stdout, "Update Success")
-		byt := makeTestingMessage("Update success")
+		byt := makeStatusMessage(200)
 		return byt
 	} else {
 		fmt.Fprintf(os.Stdout, "Update Failure")
-		byt := makeTestingMessage("Update failed")
+		byt := makeStatusMessage(400)
 		return byt
 	}
 }
@@ -329,11 +329,23 @@ func (api *ApiServer) wsEndpoint(w http.ResponseWriter, r *http.Request) {
 
 func makeTestingMessage(s string) []byte {
 	msg := TestingMsg{
-		Type: Testing,
+		Type: DrawResponse,
 		Msg:  s,
 	}
 
-	// var b []byte
+	b, err := json.Marshal(msg)
+	if err != nil {
+		log.Println(err)
+	}
+	return b
+}
+
+func makeStatusMessage(s int) []byte {
+	msg := DrawResponseMsg{
+		Type:   DrawResponse,
+		Status: s,
+	}
+
 	b, err := json.Marshal(msg)
 	if err != nil {
 		log.Println(err)

--- a/server/apiserver/message.go
+++ b/server/apiserver/message.go
@@ -1,21 +1,29 @@
 package apiserver
 
-type MsgType uint8
+type MsgType int8
 
 // Well defined Message types
 const (
-	Open      MsgType = 0
-	DrawPixel MsgType = 1
-	LoginUser MsgType = 2
-	Image     MsgType = 4
-	Testing   MsgType = 5
-	Close     MsgType = 9
+	Error        MsgType = -1
+	Open         MsgType = 0
+	DrawPixel    MsgType = 1
+	LoginUser    MsgType = 2
+	UpdatePixel  MsgType = 3
+	Image        MsgType = 4
+	Testing      MsgType = 5
+	DrawResponse MsgType = 6
+	Close        MsgType = 9
 )
 
 type Msg struct {
 	Type MsgType `json:"type"`
 }
 
+/*
+	This message type is intended to be sent from
+	the client to the server, signifying that the
+	user would like to change a pixel on the canvas.
+*/
 type DrawPixelMsg struct {
 	Type   MsgType `json:"type"`
 	X      int     `json:"x"`
@@ -31,6 +39,21 @@ type LoginUserMsg struct {
 	Id   string  `json:"id"`
 }
 
+/*
+	This message type is intended to be sent from
+	the server to the client, notifying the user
+	that a pixel was drawn by another user.
+*/
+type UpdatePixelMsg struct {
+	Type   MsgType `json:"type"`
+	X      int     `json:"x"`
+	Y      int     `json:"y"`
+	R      int     `json:"r"`
+	G      int     `json:"g"`
+	B      int     `json:"b"`
+	UserID string  `json:"userID"`
+}
+
 type ImageMsg struct {
 	Type         MsgType `json:"type"`
 	FormatString string  `json:"formatString"`
@@ -39,4 +62,9 @@ type ImageMsg struct {
 type TestingMsg struct {
 	Type MsgType `json:"type"`
 	Msg  string  `json:"msg"`
+}
+
+type DrawResponseMsg struct {
+	Type   MsgType `json:"type"`
+	Status int     `json:"status"`
 }


### PR DESCRIPTION
The grid now has the structure on the client side to read the grid from consensus and to display it.
The HTTP `/get_image` path is back in the code to allow easy access to look at the grid in consensus.
The button on our testing page now has a loop to set many pixels so you can easily more notice it on the grid.
Added in some more messages to be used in the future.