### PR TITLE
Fixing syntax errors in apiserver.go

### DIFF
--- a/server/apiserver/apiserver.go
+++ b/server/apiserver/apiserver.go
@@ -56,11 +56,12 @@ func (api *ApiServer) ListenAndServe() {
 	http.ListenAndServe(fmt.Sprintf(":%d", api.port), nil)
 }
 
+
 func (api *ApiServer) HTTPGetImage(w http.ResponseWriter, req *http.Request) {
-	// This has only been added back for debugging purposes and will probably be removed in the final thing.
+	// This is the method that will be removed. Displays the image on a webpage
+
 	// Debug message
 	fmt.Fprintf(os.Stdout, "Getting Image From Raft\n")
-	fmt.Fprintf(os.Stdout, "Called from http writer. n")
 	// Construct the message
 	m := consensus.BackendMessage{Type: consensus.GET_IMAGE}
 	// Send a message through the channel
@@ -68,21 +69,14 @@ func (api *ApiServer) HTTPGetImage(w http.ResponseWriter, req *http.Request) {
 	var ImageTemplate string = `<!DOCTYPE html>
 								<html lang="en"><head></head>
 								<body><img src="data:image/jpg;base64,{{.Image}}"></body>`
-	imageMsg := <-api.recvc
 	image_msg := <-api.recvc
-
-	if _, err := template.New("image").Parse(ImageTemplate); err != nil {
 	if tmpl, err := template.New("image").Parse(ImageTemplate); err != nil {
 		fmt.Fprintf(os.Stdout, "Unable to parse image template.\n")
-		return "Unable to parse image template"
 	} else {
-
 		// Decode the message from the glob
-		dec := gob.NewDecoder(&imageMsg.Data)
 		dec := gob.NewDecoder(&image_msg.Data)
 		var img image.RGBA
 		dec.Decode(&img)
-
 		// In-memory buffer to store PNG image
 		// before we base 64 encode it
 		var buff bytes.Buffer
@@ -91,15 +85,12 @@ func (api *ApiServer) HTTPGetImage(w http.ResponseWriter, req *http.Request) {
 		png.Encode(&buff, &img)
 		// Encode the bytes in the buffer to a base64 string
 		encodedString := base64.StdEncoding.EncodeToString(buff.Bytes())
-
-		// TODO  wrap the encodedString in a message
-
-		return encodedString
 		data := map[string]interface{}{"Image": encodedString}
 		if err = tmpl.Execute(w, data); err != nil {
 			fmt.Fprintf(os.Stdout, "Unable to execute template.\n")
 		}
 	}
+}
 
 func (api *ApiServer) CallGetImage() string {
 	// Debug message


### PR DESCRIPTION
I accidentally merged a syntax error a few days ago. This fixes the braces and the duplicate lines. I think it got messed up in a merge conflict. This function is currently only used when you want to see the backend grid without starting up the client grid.