### PR TITLE
Remaining cool-down time can be sent successfully to the front-end whenever a user logs in.

### DIFF
--- a/client/src/message.ts
+++ b/client/src/message.ts
@@ -9,7 +9,7 @@ export enum MsgType {
     DRAWRESPONSE = 6,
     CLOSE = 9,
     VERIFICATIONFAIL = 10,
-    CREATEUSER = 11
+    USERLOGIN = 11
 }
 
 export interface Msg {
@@ -56,8 +56,8 @@ export class VerificationFailMsg implements Msg {
     }
 }
 
-export class CreateUserMsg implements Msg {
-    type: number = MsgType.CREATEUSER;
+export class UserLoginMsg implements Msg {
+    type: number = MsgType.USERLOGIN;
     status: number;
     cooldown: number;
     

--- a/client/src/message.ts
+++ b/client/src/message.ts
@@ -56,7 +56,7 @@ export class VerificationFailMsg implements Msg {
     }
 }
 
-export class UserLoginMsg implements Msg {
+export class UserLoginResponseMsg implements Msg {
     type: number = MsgType.USERLOGIN;
     status: number;
     cooldown: number;

--- a/client/src/message.ts
+++ b/client/src/message.ts
@@ -9,7 +9,7 @@ export enum MsgType {
     DRAWRESPONSE = 6,
     CLOSE = 9,
     VERIFICATIONFAIL = 10,
-    USERLOGIN = 11
+    USERLOGINRESPONSE = 11
 }
 
 export interface Msg {
@@ -57,7 +57,7 @@ export class VerificationFailMsg implements Msg {
 }
 
 export class UserLoginResponseMsg implements Msg {
-    type: number = MsgType.USERLOGIN;
+    type: number = MsgType.USERLOGINRESPONSE;
     status: number;
     cooldown: number;
     

--- a/client/src/websocket/actions.ts
+++ b/client/src/websocket/actions.ts
@@ -102,9 +102,9 @@ export const openWebSocket = () => (dispatch, getState) => {
           }
           break;
         }
-        case MsgType.USERLOGIN: {
+        case MsgType.USERLOGINRESPONSE: {
           let status = json.status
-          let cooldown = json.Cooldown
+          let cooldown = json.cooldown
           console.log("Received a USERLOGIN message from the server!");
           console.log("The status was " + status);
           console.log("The remaining cooldown time for current user is: " + cooldown);

--- a/client/src/websocket/actions.ts
+++ b/client/src/websocket/actions.ts
@@ -101,7 +101,7 @@ export const openWebSocket = () => (dispatch, getState) => {
           }
           break;
         }
-        case MsgType.CREATEUSER: {
+        case MsgType.USERLOGIN: {
           let status = json.status
           let cooldown = json.cooldown
           console.log("Received a CREATEUSER message from the server!");

--- a/client/src/websocket/actions.ts
+++ b/client/src/websocket/actions.ts
@@ -59,6 +59,7 @@ export const openWebSocket = () => (dispatch, getState) => {
   socket.onmessage = event => {
     const { data } = event;
     let json = JSON.parse(data);
+    console.log("RECEIVED: " + json.type);
     switch (json.type) {
         case MsgType.IMAGE: {
             // let msg = new ImageMsg(data.formatString); //now what?
@@ -104,7 +105,7 @@ export const openWebSocket = () => (dispatch, getState) => {
         case MsgType.USERLOGIN: {
           let status = json.status
           let cooldown = json.Cooldown
-          console.log("Received a CREATEUSER message from the server!");
+          console.log("Received a USERLOGIN message from the server!");
           console.log("The status was " + status);
           console.log("The remaining cooldown time for current user is: " + cooldown);
           break;

--- a/server/apiserver/apiserver.go
+++ b/server/apiserver/apiserver.go
@@ -8,8 +8,10 @@ import (
 	"html/template"
 	"image"
 	"image/png"
+	"math"
 	"net/http"
 	"sync"
+	"strconv"
 	"time"
 
 	gwebsocket "github.com/gorilla/websocket"
@@ -50,7 +52,7 @@ type Client struct {
 	Pool *Pool
 }
 
-var cooldown = 300000
+var cooldown, _ = time.ParseDuration("5m")
 
 func NewApiServer(servers map[int]*common.ServerConfig, nodeId int) (*ApiServer, error) {
 
@@ -89,7 +91,7 @@ func (api *ApiServer) ListenAndServe() {
 		api.serveWs(pool, w, r)
 	})
 	http.HandleFunc("/update_pixel", api.HTTPUpdatePixel)
-	http.HandleFunc("/update_user", api.HTTPUpdateUserList)
+	http.HandleFunc("/update_user", api.HTTPUserLogin)
 
 	// Although there is nothing wrong with this line, it prevents us from
 	// running multiple nodes on a single machine.  Therefore, I am making
@@ -175,23 +177,32 @@ func (api *ApiServer) HTTPUpdatePixel(w http.ResponseWriter, req *http.Request) 
 	}
 }
 
-/*
- * Insert the new user id to the userlist
- */
-func (api *ApiServer) HTTPUpdateUserList(w http.ResponseWriter, req *http.Request) {
-	// Only for testing
-	user_id := req.URL.Query().Get("user_id")
-	if user_id == "" {
-		http.Error(w, errors.New("empty param: user_id").Error(), http.StatusInternalServerError)
-		return
+func (api *ApiServer) HTTPUserLogin(w http.ResponseWriter, req *http.Request) []byte {
+	userID := req.URL.Query().Get("id")
+	//if userID == "" {
+	//	http.Error(w, errors.New("empty param: userID").Error(), http.StatusInternalServerError)
+	//	return
+	//}
+	byt := makeUserLoginResponseMsg(400, -1)
+	lastMove, getErr := api.conService.SyncGetLastUserModification(userID)
+	if getErr == consensus.NoSuchUser {
+		setErr := api.conService.SyncSetLastUserModification(userID, time.Unix(0,0)) // Default Timestamp for New Users
+		if setErr != nil {
+			byt = makeUserLoginResponseMsg(200, 0)
+		}
+	} else if lastMove != nil {
+		timeSinceLastMove := time.Since(*lastMove)
+		if timeSinceLastMove.Milliseconds() >= cooldown.Milliseconds() {
+			byt = makeUserLoginResponseMsg(200, 0)
+		} else {
+			byt = makeUserLoginResponseMsg(200, int(cooldown.Milliseconds() - timeSinceLastMove.Milliseconds()))
+		}
 	}
-
-	timestamp := time.Now()
-	err := api.conService.SyncSetLastUserModification(user_id, timestamp)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	return byt
+	//if err != nil {
+	//	http.Error(w, err.Error(), http.StatusInternalServerError)
+	//	return
+	//}
 }
 
 func (api *ApiServer) serveWs(pool *Pool, w http.ResponseWriter, r *http.Request) {
@@ -278,6 +289,10 @@ func (c *Client) Read(api *ApiServer) {
 				}).Debug("received ws message")
 
 				// TODO(user team): add user verification here
+				// <Start Validate User>
+				lastMove, getErr := api.conService.SyncGetLastUserModification()
+				// <End Validate User>
+
 				err := api.conService.SyncUpdatePixel(dpMsg.X, dpMsg.Y, dpMsg.R, dpMsg.G, dpMsg.B, AlphaMask)
 				if err != nil {
 					// TODO(backend team): handle error response
@@ -321,15 +336,31 @@ func (c *Client) Read(api *ApiServer) {
 		case LoginUser:
 			fmt.Println("CreateUser message received.")
 			var cu_msg LoginUserMsg
+			fmt.Println(cu_msg)
 			if err := json.Unmarshal(p, &cu_msg); err == nil {
 				log.WithFields(log.Fields{
 					"message": cu_msg,
 				}).Debug("received ws message")
 
-				timestamp := time.Now()
-				err := api.conService.SyncSetLastUserModification(cu_msg.Id, timestamp)
-				if err != nil {
-					// TODO(backend team): handle error response
+				userID := cu_msg.Id
+				//if userID == "" {
+				//	http.Error(w, errors.New("empty param: userID").Error(), http.StatusInternalServerError)
+				//	return
+				//}
+				byt := makeUserLoginResponseMsg(400, -1)
+				lastMove, getErr := api.conService.SyncGetLastUserModification(userID)
+				if getErr == consensus.NoSuchUser {
+					setErr := api.conService.SyncSetLastUserModification(userID, time.Unix(0,0)) // Default Timestamp for New Users
+					if setErr != nil {
+						byt = makeUserLoginResponseMsg(200, 0)
+					}
+				} else if lastMove != nil {
+					timeSinceLastMove := time.Since(*lastMove)
+					if timeSinceLastMove.Milliseconds() >= cooldown.Milliseconds() {
+						byt = makeUserLoginResponseMsg(200, 0)
+					} else {
+						byt = makeUserLoginResponseMsg(200, int(cooldown.Milliseconds() - timeSinceLastMove.Milliseconds()))
+					}
 				}
 
 			} else {
@@ -407,9 +438,9 @@ func makeVerificationFailMessage(s int) []byte {
 	return b
 }
 
-func makeCreateUserMessage(s int, c int) []byte {
-	msg := CreateUserMsg{
-		Type:     CreateUser,
+func makeUserLoginResponseMsg(s int, c int) []byte {
+	msg := UserLoginResponseMsg{
+		Type:     UserLoginResponse,
 		Status:   s,
 		Cooldown: c,
 	}

--- a/server/apiserver/apiserver.go
+++ b/server/apiserver/apiserver.go
@@ -359,9 +359,8 @@ func (c *Client) Read(api *ApiServer) {
 		// 	}
 
 		case LoginUser:
-			fmt.Println("CreateUser message received.")
+			fmt.Println("LoginUser message received.")
 			var cu_msg LoginUserMsg
-			fmt.Println(cu_msg)
 			if err := json.Unmarshal(p, &cu_msg); err == nil {
 				log.WithFields(log.Fields{
 					"message": cu_msg,
@@ -372,7 +371,7 @@ func (c *Client) Read(api *ApiServer) {
 				//	http.Error(w, errors.New("empty param: userID").Error(), http.StatusInternalServerError)
 				//	return
 				//}
-				byt := makeUserLoginResponseMsg(400, -1)
+				byt = makeUserLoginResponseMsg(400, -1)
 				lastMove, getErr := api.conService.SyncGetLastUserModification(userID)
 				if getErr == consensus.NoSuchUser {
 					setErr := api.conService.SyncSetLastUserModification(userID, time.Unix(0,0)) // Default Timestamp for New Users

--- a/server/apiserver/apiserver.go
+++ b/server/apiserver/apiserver.go
@@ -288,12 +288,6 @@ func (c *Client) Read(api *ApiServer) {
 				fmt.Println("<Start Validate User>")
 				lastMove, getErr := api.conService.SyncGetLastUserModification(dpMsg.UserID)
 
-				//fmt.Println("@@@")
-				//fmt.Println(dpMsg.UserID)
-				//fmt.Println(lastMove)
-				//fmt.Println(getErr)
-				//fmt.Println("@@@")
-
 				var userVerification int
 				if getErr != nil {
 					// Cannot get this user's last modification
@@ -372,8 +366,6 @@ func (c *Client) Read(api *ApiServer) {
 				log.WithFields(log.Fields{
 					"message": cu_msg,
 				}).Debug("received ws message")
-				fmt.Println("p =", string(p))
-				fmt.Println("cu_msg =", cu_msg, "Email", cu_msg.Email)
 				userID := cu_msg.Email
 				//if userID == "" {
 				//	http.Error(w, errors.New("empty param: userID").Error(), http.StatusInternalServerError)
@@ -381,20 +373,10 @@ func (c *Client) Read(api *ApiServer) {
 				//}
 				byt = makeUserLoginResponseMsg(400, -1)
 				lastMove, getErr := api.conService.SyncGetLastUserModification(userID)
-				//fmt.Println("!!!")
-				//fmt.Println(lastMove)
-				//fmt.Println(getErr)
-				//fmt.Println("!!!")
 				if getErr == consensus.NoSuchUser {
 					setErr := api.conService.SyncSetLastUserModification(userID, time.Unix(0,0)) // Default Timestamp for New Users
 					if setErr == nil {
 						byt = makeUserLoginResponseMsg(200, 0)
-						//lasttime, getErr1 := api.conService.SyncGetLastUserModification(userID)
-						//fmt.Println("???")
-						//fmt.Println(userID)
-						//fmt.Println(lasttime)
-						//fmt.Println(getErr1)
-						//fmt.Println("???")
 					}
 				} else if lastMove != nil {
 					timeSinceLastMove := time.Since(*lastMove)
@@ -414,7 +396,7 @@ func (c *Client) Read(api *ApiServer) {
 			// this is what the case is if the message is recieved from other servers
 			fmt.Printf("Message of type: %d received.\n", dat.Type)
 		}
-
+		// Check the response message
 		fmt.Println("byt:", string(byt))
 		api.Mux.Lock()
 		if err := c.Conn.WriteMessage(gwebsocket.TextMessage, byt); err != nil {

--- a/server/apiserver/message.go
+++ b/server/apiserver/message.go
@@ -98,7 +98,7 @@ func NewDrawPixelMsg(req *http.Request) (*DrawPixelMsg, error) {
 
 type LoginUserMsg struct {
 	Type MsgType `json:"type"`
-	Id   string  `json:"id"`
+	Email   string  `json:"email"`
 }
 
 /*

--- a/server/apiserver/message.go
+++ b/server/apiserver/message.go
@@ -21,7 +21,7 @@ const (
 	DrawResponse      MsgType = 6
 	Close             MsgType = 9
 	VerificationFail  MsgType = 10
-	CreateUser        MsgType = 11
+	UserLoginResponse MsgType = 11
 )
 
 type Msg struct {
@@ -136,7 +136,7 @@ type VerificationFailMsg struct {
 	Status int     `json:"status"`
 }
 
-type CreateUserMsg struct {
+type UserLoginResponseMsg struct {
 	Type     MsgType `json:"type"`
 	Status   int     `json:"status"`
 	Cooldown int     `json:"cooldown`

--- a/server/apiserver/message.go
+++ b/server/apiserver/message.go
@@ -139,5 +139,5 @@ type VerificationFailMsg struct {
 type UserLoginResponseMsg struct {
 	Type     MsgType `json:"type"`
 	Status   int     `json:"status"`
-	Cooldown int     `json:"cooldown`
+	Cooldown int     `json:"cooldown"`
 }

--- a/server/consensus/consensus.go
+++ b/server/consensus/consensus.go
@@ -75,8 +75,8 @@ const (
 )
 
 var (
-	dragonboatConfigurationError = errors.New("dragonboat configuration")
-	noSuchUser                   = errors.New("no such user")
+	DragonboatConfigurationError = errors.New("dragonboat configuration")
+	NoSuchUser                   = errors.New("no such user")
 )
 
 type IConsensus interface {
@@ -220,7 +220,7 @@ func (cs *ConsensusService) SyncGetLastUserModification(userId string) (*time.Ti
 	}
 	resultString := string(result.([]byte))
 	if resultString == "" {
-		return nil, noSuchUser
+		return nil, NoSuchUser
 	}
 
 	t, err := time.Parse(common.TimeFormat, resultString)


### PR DESCRIPTION
Once the front-end changed the timer implementation, "user validation" can then be tested.