### PR TITLE
ci: backend and frontend actions for build n test

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,6 +6,6 @@ jobs:
   build-backend:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1.0.0
     - name: build backend image
       run: make image

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -3,7 +3,7 @@ name: build & test backend
 on: [push, pull_request]
 
 jobs:
-  build-deploy:
+  build-backend:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,6 +1,6 @@
 name: build & test backend
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   build-backend:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -3,19 +3,12 @@ name: build & test frontend
 on: [push, pull_request]
 
 jobs:
-  build-deploy-frontend:
-    runs-on: ubuntu-latest
+  build-frontend:
+    runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1.0.0
     - name: build site
       working-directory: ./client
       run: |
         npm install
         npm run build
-    - name: deploy to gh-pages
-      uses: JamesIves/github-pages-deploy-action@releases/v3
-      with:
-        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        BASE_BRANCH: master # The branch the action should deploy from.
-        BRANCH: gh-pages # The branch the action should deploy to.
-        FOLDER: build # The folder the action should deploy.

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,21 @@
+name: build & test frontend
+
+on: [push, pull_request]
+
+jobs:
+  build-deploy-frontend:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: build site
+      working-directory: ./client
+      run: |
+        npm install
+        npm run build
+    - name: deploy to gh-pages
+      uses: JamesIves/github-pages-deploy-action@releases/v3
+      with:
+        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        BASE_BRANCH: master # The branch the action should deploy from.
+        BRANCH: gh-pages # The branch the action should deploy to.
+        FOLDER: build # The folder the action should deploy.

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,6 +1,6 @@
 name: build & test frontend
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   build-frontend:

--- a/client/src/canvas/actions.ts
+++ b/client/src/canvas/actions.ts
@@ -2,7 +2,7 @@
 // import { HOSTNAME } from '../constants';
 import { Color } from './types';
 import * as ActionTypes from './actionTypes';
-import { getZoomFactor, getCanvasContext } from './selectors';
+import { getZoomFactor } from './selectors';
 import { getWebSocket } from '../websocket/selectors';
 import { getUserEmail } from '../login/selectors';
 import { connectError, makeUpdateMessage } from '../websocket/actions';

--- a/client/src/canvas/components/Canvas.tsx
+++ b/client/src/canvas/components/Canvas.tsx
@@ -1,6 +1,6 @@
 import React, { Component, createRef, RefObject } from 'react';
 import ColorPicker from '../../colorPicker/components/colorPicker';
-import { Redirect } from 'react-router-dom';
+//import { Redirect } from 'react-router-dom';
 import './Canvas.scss';
 import { Icon, Spin, notification } from 'antd';
 import { ZOOM_CHANGE_FACTOR } from '../constants';
@@ -8,7 +8,7 @@ import { Color, RGBColor } from 'react-color';
 import classNames from 'classnames';
 
 interface Props {
-  receivedError: boolean;
+  //receivedError: boolean;
   isLoading: boolean;
   registerContext: (context: CanvasRenderingContext2D) => void;
   updatePosition: (x: number, y: number) => void;
@@ -259,7 +259,8 @@ class Canvas extends Component<Props, State> {
   }
 
   render() {
-    const { receivedError, zoomFactor, setZoomFactor, isLoading } = this.props;
+    //const { receivedError, zoomFactor, setZoomFactor, isLoading } = this.props;
+    const { zoomFactor, setZoomFactor, isLoading } = this.props;
     const {
       translateX,
       translateY,

--- a/client/src/header/components/Header.tsx
+++ b/client/src/header/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState, useEffect } from 'react';
-import { PageHeader, Button, Menu, Dropdown, Icon, notification } from 'antd';
+import { PageHeader, Button, Menu, Dropdown, Icon } from 'antd';
 import { Link, useLocation } from 'react-router-dom';
 import './Header.scss';
 
@@ -81,10 +81,6 @@ const Header: FC<Props> = ({
     if (time <= 0) {
       clearInterval(interval);
       setTimeRemaining(0);
-    //   notification.success({
-    //     message: 'Place another pixel',
-    //     description: 'You can now update another pixel on the canvas.'
-    //   });
       return;
     }
 

--- a/client/src/login/actions.ts
+++ b/client/src/login/actions.ts
@@ -1,6 +1,6 @@
 import * as ActionTypes from './actionTypes';
 import { getWebSocket } from '../websocket/selectors';
-import { makeLoginMessage, connectError, sendLoginMessage } from '../websocket/actions';
+import { makeLoginMessage, connectError } from '../websocket/actions';
 
 const loginStart = () => ({
   type: ActionTypes.LoginStart

--- a/client/src/websocket/actions.ts
+++ b/client/src/websocket/actions.ts
@@ -99,7 +99,7 @@ export const openWebSocket = () => (dispatch, getState) => {
               dispatch(setColor(x, y, r, g, b));
               dispatch({ type: CanvasActionTypes.UpdatePixelError });
             }
-          } else if (status == 429) {
+          } else if (status === 429) {
             // If the user's cooldown hasn't expired yet
             if (json.remainingTime > 0) {
               dispatch(setTimeToNextMove(json.remainingTime));


### PR DESCRIPTION
This patch introduces two CI jobs: one to build and deploy our frontend
(static site) to gh-pages and one to build our backend code.  This will
prevent patches that break compilation, but we do not run (any) tests on
either codebase.  Additionally, I don't believe anything is cached when
building the backend, so CI runs are going to be really fucking long...