### PR TITLE
backend: fix cooldown response

### DIFF
--- a/server/wsutil/conn.go
+++ b/server/wsutil/conn.go
@@ -90,7 +90,7 @@ func (c *Client) handleDrawPixel(p []byte) {
 		// Here we'd like to send a message to the client indicating that they
 		// need to wait a bit longer before making another change to the
 		// canvas.
-		message := common.MakeVerificationFailMessage(0)
+		message := common.MakeVerificationFailMessage(int(common.Cooldown.Seconds() - timeSinceLastMove.Seconds()))
 		c.Send <- message
 		return
 	}


### PR DESCRIPTION
This patch fixes the cooldown response when the user must still wait
before sending a pixel.