### PR TITLE
backend: include cooldown in DrawResponseMsg

### DIFF
--- a/client/src/websocket/actions.ts
+++ b/client/src/websocket/actions.ts
@@ -101,9 +101,8 @@ export const openWebSocket = () => (dispatch, getState) => {
             }
           } else if (status == 429) {
             // If the user's cooldown hasn't expired yet
-            let remainingTime = json.remainingTime;
-            if (remainingTime > 0) {
-              dispatch(setTimeToNextMove(remainingTime));
+            if (json.remainingTime > 0) {
+              dispatch(setTimeToNextMove(json.remainingTime));
             } else {
               // this might happen if someone manually makes a status message with code 429...
               console.log("Received an ill-formatted DRAWRESPONSE cooldown message from the server!");

--- a/client/src/websocket/actions.ts
+++ b/client/src/websocket/actions.ts
@@ -99,6 +99,15 @@ export const openWebSocket = () => (dispatch, getState) => {
               dispatch(setColor(x, y, r, g, b));
               dispatch({ type: CanvasActionTypes.UpdatePixelError });
             }
+          } else if (status == 429) {
+            // If the user's cooldown hasn't expired yet
+            let remainingTime = json.remainingTime;
+            if (remainingTime > 0) {
+              dispatch(setTimeToNextMove(remainingTime));
+            } else {
+              // this might happen if someone manually makes a status message with code 429...
+              console.log("Received an ill-formatted DRAWRESPONSE cooldown message from the server!");
+            }
           } else {
             dispatch({ type: CanvasActionTypes.UpdatePixelSuccess });
           }

--- a/server/common/message.go
+++ b/server/common/message.go
@@ -149,6 +149,7 @@ type TestingMsg struct {
 type DrawResponseMsg struct {
 	Type   MsgType `json:"type"`
 	Status int     `json:"status"`
+	RemainingTime int `json:"remainingTime"`
 }
 
 type VerificationFailMsg struct {
@@ -179,6 +180,21 @@ func MakeStatusMessage(s int) []byte {
 	msg := DrawResponseMsg{
 		Type:   DrawResponse,
 		Status: s,
+		RemainingTime: -1,
+	}
+
+	b, err := json.Marshal(msg)
+	if err != nil {
+		log.Println(err)
+	}
+	return b
+}
+
+func MakeCooldownMessage(time int) []byte {
+	msg := DrawResponseMsg{
+		Type:   DrawResponse,
+		Status: 429,
+		RemainingTime: time,
 	}
 
 	b, err := json.Marshal(msg)

--- a/server/common/message.go
+++ b/server/common/message.go
@@ -147,9 +147,9 @@ type TestingMsg struct {
 }
 
 type DrawResponseMsg struct {
-	Type   MsgType `json:"type"`
-	Status int     `json:"status"`
-	RemainingTime int `json:"remainingTime"`
+	Type          MsgType `json:"type"`
+	Status        int     `json:"status"`
+	RemainingTime int     `json:"remainingTime"`
 }
 
 type VerificationFailMsg struct {
@@ -176,11 +176,11 @@ func MakeTestingMessage(s string) []byte {
 	return b
 }
 
-func MakeStatusMessage(s int) []byte {
+func MakeStatusMessage(s int, remaining int) []byte {
 	msg := DrawResponseMsg{
-		Type:   DrawResponse,
-		Status: s,
-		RemainingTime: -1,
+		Type:          DrawResponse,
+		Status:        s,
+		RemainingTime: remaining,
 	}
 
 	b, err := json.Marshal(msg)
@@ -192,8 +192,8 @@ func MakeStatusMessage(s int) []byte {
 
 func MakeCooldownMessage(time int) []byte {
 	msg := DrawResponseMsg{
-		Type:   DrawResponse,
-		Status: 429,
+		Type:          DrawResponse,
+		Status:        429,
 		RemainingTime: time,
 	}
 

--- a/server/wsutil/conn.go
+++ b/server/wsutil/conn.go
@@ -90,7 +90,7 @@ func (c *Client) handleDrawPixel(p []byte) {
 		// Here we'd like to send a message to the client indicating that they
 		// need to wait a bit longer before making another change to the
 		// canvas.
-		message := common.MakeVerificationFailMessage(0)
+		message := common.MakeCooldownMessage(int(common.Cooldown.Seconds() - timeSinceLastMove.Seconds()))
 		c.Send <- message
 		return
 	}

--- a/server/wsutil/conn.go
+++ b/server/wsutil/conn.go
@@ -29,7 +29,6 @@ const (
 	wsUpgraderReadBufferSize  = 1024
 	wsUpgraderWriteBufferSize = 1024
 )
-const ()
 
 var (
 	newline  = []byte{'\n'}
@@ -98,7 +97,7 @@ func (c *Client) handleDrawPixel(p []byte) {
 	err = c.cons.SyncUpdatePixel(dpMsg.X, dpMsg.Y, dpMsg.R, dpMsg.G, dpMsg.B, common.AlphaMask)
 	if err != nil {
 		// Here we'd like to indicate a server error to the client.
-		message := common.MakeStatusMessage(503)
+		message := common.MakeStatusMessage(503, int(timeSinceLastMove.Seconds()))
 		c.Send <- message
 		return
 	}
@@ -106,7 +105,7 @@ func (c *Client) handleDrawPixel(p []byte) {
 	err = c.cons.SyncSetLastUserModification(dpMsg.UserID, time.Now())
 	if err != nil {
 		// Here we'd like to indicate a server error to the client.
-		message := common.MakeStatusMessage(503)
+		message := common.MakeStatusMessage(503, int(common.Cooldown.Seconds()))
 		c.Send <- message
 		return
 	}


### PR DESCRIPTION
DRAWRESPONSE messages now have a remainingTime field that should be > 0 if the status is 429 (indicating that you still have cooldown time remaining).  Wasn't able to test this as refreshing the page  seems to reset the image and cooldown timer, but it doesn't break anything as far as I can tell.